### PR TITLE
chore: add security checks [AUOPS-4011]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,11 @@
+parameters:
+  - name: buildStages
+    type: object
+    default:
+      - Build
+      - Security_FOSSA
+      - Security_CODEQL
+
 trigger:
   batch: true
   branches:
@@ -20,6 +28,16 @@ resources:
       name: UiPath/AzurePipelinesTemplates
       ref: master
       endpoint: "GitHub connection"
+    - repository: codeql
+      name: UiPath/AzurePipelinesTemplates
+      ref: refs/tags/uipath.security.codeql.1.8.13
+      type: github
+      endpoint: "GitHub connection"
+    - repository: fossa
+      name: UiPath/AzurePipelinesTemplates
+      ref: refs/tags/uipath.security.fossa.2.0.0
+      type: github
+      endpoint: "GitHub connection"
 
 variables:
   JENKINS_HOME: 'C:\Windows\System32\config\systemprofile\.jenkins'
@@ -29,29 +47,16 @@ variables:
   TestConfigurationData: "{\"Publishers\":[{\"Type\":\"JUnit\",\"Arguments\":\"outputFile=junitResults.xml;reportSkippedTestSuite=False\"}], \"VideoRecorderType\": \"ffmpeg\", \"VideoRecorderPath\": \"C:\\\\\\\\ffmpeg\\\\\\\\ffmpeg.exe\"}"
 
 stages:
-- stage: Build
-  displayName: "Build CLI package"
-  jobs:
-  - job: BuildAndPublishArtifacts
-    displayName: 'Build'
-    timeoutInMinutes: 90
-    workspace:
-      clean: outputs
-    variables:
-      MavenPOMFile: '$(Build.SourcesDirectory)/pom.xml'
-    pool:
-      vmImage: windows-2022
-      demands:
-        - maven
-    steps:
-    - template: job.ci.build.yml
-
-- ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/develop'), startsWith(variables['Build.SourceBranch'], 'refs/heads/masters/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/support/')) }}:
-  - stage: BuildSecurityScan
-    displayName: Build and Security Scan
-    dependsOn: []
-    jobs:
-    - template: stage.security.yml
+- ${{ each stageName in parameters.buildStages }}:
+    - stage: ${{ stageName }}
+      displayName: ${{ replace(stageName, '_', ' ') }}
+      dependsOn: []
+      jobs:
+        - template: build.jobs.template.yml
+          parameters:
+            name: ${{ replace(stageName, 'Security_', '') }}
+            ${{ if contains(stageName, 'Security') }}:
+              securityScan: ${{ replace(stageName, 'Security_', '') }}
 
 - stage: Deploy
   displayName: "Deploy on Jenkins server"

--- a/build.jobs.template.yml
+++ b/build.jobs.template.yml
@@ -1,0 +1,44 @@
+parameters:
+  name: ''
+  securityScan: ''
+
+jobs:
+  - job: ${{ parameters.name }}
+    displayName: ${{ parameters.name }}
+    timeoutInMinutes: 90
+    workspace:
+      clean: outputs
+    variables:
+      MavenPOMFile: '$(Build.SourcesDirectory)/pom.xml'
+    pool:
+      vmImage: windows-latest
+      demands:
+        - maven
+    steps:
+      - ${{ if eq(parameters.securityScan, 'CODEQL') }}:
+          - template: Security/codeql.pre-build.steps.yml@codeql
+            parameters:
+              os: 'win64'
+              language: 'java'
+
+      - template: job.ci.build.yml
+        parameters:
+          ${{ if eq(parameters.securityScan, '') }}:
+            publishArtifacts: true
+
+      - ${{ if eq(parameters.securityScan, 'CODEQL') }}:
+          - template: Security/codeql.post-build.steps.yml@codeql
+            parameters:
+              os: 'win64'
+              language: 'java'
+              azureSubscription: 'Internal-Production-EA'
+              skipDatabasePublish: true
+
+      - ${{ if eq(parameters.securityScan, 'FOSSA') }}:
+          - template: Security/fossa.steps.yml@fossa
+            parameters:
+              removeSpecificPath: true
+              OS: 'windows'
+              azureSubscription: 'Internal-Production-EA'
+              FOSSAFlags: '--project "JenkinsPlugin" --branch "$(Build.SourceBranchName)" --revision "$(Build.SourceVersion)-$(Build.BuildId)"'
+              FOSSATestFlags: '--project "JenkinsPlugin" --revision "$(Build.SourceVersion)-$(Build.BuildId)"'

--- a/job.ci.build.yml
+++ b/job.ci.build.yml
@@ -39,8 +39,9 @@ steps:
     sqMavenPluginVersionChoice: 'latest'
     options: '-DskipTests -Duser.name=UiPath --no-transfer-progress -Dmaven.artifact.threads=16 -T 4 -DrerunFailingTestsCount=0'
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish package'
-  inputs:
-    PathtoPublish: '$(system.defaultworkingdirectory)/target/uipath-automation-package.hpi'
-    ArtifactName: Packages
+- ${{ if eq(parameters.publishArtifacts, 'true') }}:
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish package'
+      inputs:
+        PathtoPublish: '$(system.defaultworkingdirectory)/target/uipath-automation-package.hpi'
+        ArtifactName: Packages

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <envinject.version>2.4.0</envinject.version>
         <mockito-core.version>4.8.0</mockito-core.version>
         <plain-credentials.version>179.vc5cb_98f6db_38</plain-credentials.version>
-        <json.version>20220924</json.version>
+        <json.version>20231013</json.version>
         <credentials.version>1319.v7eb_51b_3a_c97b_</credentials.version>
         <org.jenkins-ci.plugins.junit.version>1265.v65b_14fa_f12f0</org.jenkins-ci.plugins.junit.version>
         <JUnitParams.version>1.1.1</JUnitParams.version>
@@ -31,7 +31,7 @@
         <symbol-annotation.version>1.23</symbol-annotation.version>
         <junit.junit.version>4.13.2</junit.junit.version>
         <localization-support.version>1.2</localization-support.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <structs.version>325.vcb_307d2a_2782</structs.version>
         <caffeine-api.version>3.1.8-133.v17b_1ff2e0599</caffeine-api.version>
         <instance-identity.version>185.v303dc7c645f9</instance-identity.version>


### PR DESCRIPTION
## What changed?
###### Add security checks.

## Why is this change necessary?
###### For Compliance Scorecard.

## How has this been tested?
Manually uploaded (because of an Azure issue with enabling public access to storage account) plugin artifact from CI pipeline to jenkins server and executed a RunJob and RunTests e2e test.

No CodeQL issues
![image](https://github.com/user-attachments/assets/b280e9ae-f26b-4d1d-99ad-98e1c1c180a7)

No FOSSA issues
![image](https://github.com/user-attachments/assets/f07ca682-6b6e-4917-8ad3-eb7a73b9af7d)


## Are there any breaking changes?
- [x] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version