### PR TITLE
feat: create process with custom name [AUOPS-3366]

### DIFF
--- a/src/main/java/com/uipath/uipathpackage/UiPathDeploy.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathDeploy.java
@@ -45,6 +45,8 @@ public class UiPathDeploy extends Recorder implements SimpleBuildStep {
     private final String entryPointPaths;
     private final boolean createProcess;
     private Boolean ignoreLibraryDeployConflict;
+    private String processName;
+    private String processNames;
 
     /**
      * Data bound constructor which is responsible for setting/saving of the values
@@ -227,6 +229,17 @@ public class UiPathDeploy extends Recorder implements SimpleBuildStep {
                 deployOptions.setIgnoreLibraryDeployConflict(ignoreLibraryDeployConflict);
             }
 
+            if (processName != null && !processName.isEmpty()) {
+                deployOptions.setProcessName(processName);
+            }
+
+            if (processNames != null && !processNames.isEmpty()) {
+                FilePath expandedprocessNamesPath = processNames.contains("${WORKSPACE}") ?
+                        new FilePath(launcher.getChannel(), envVars.expand(processNames)) :
+                        workspace.child(envVars.expand(processNames));
+                deployOptions.setProcessNames(expandedprocessNamesPath.getRemote());
+            }
+
             deployOptions.setPackagesPath(expandedPackagePath.getRemote());
             deployOptions.setOrchestratorUrl(orchestratorAddress);
             deployOptions.setOrganizationUnit(envVars.expand(folderName.trim()));
@@ -300,6 +313,24 @@ public class UiPathDeploy extends Recorder implements SimpleBuildStep {
 
     public Boolean getIgnoreLibraryDeployConflict() {
         return ignoreLibraryDeployConflict;
+    }
+
+    @DataBoundSetter
+    public void setProcessName(String processName) {
+        this.processName = processName;
+    }
+
+    public String getProcessName() {
+        return processName;
+    }
+
+    @DataBoundSetter
+    public void setProcessNames(String processNames) {
+        this.processNames = processNames;
+    }
+
+    public String getProcessNames() {
+        return processNames;
     }
 
     /**

--- a/src/main/java/com/uipath/uipathpackage/models/DeployOptions.java
+++ b/src/main/java/com/uipath/uipathpackage/models/DeployOptions.java
@@ -8,6 +8,8 @@ public class DeployOptions extends CommonOptions {
     private List<String> entryPointPaths;
     private boolean createProcess;
     private Boolean ignoreLibraryDeployConflict = null;
+    private String processName;
+    private String processNames;
 
     public String getPackagesPath() {
         return packagesPath;
@@ -47,5 +49,21 @@ public class DeployOptions extends CommonOptions {
 
     public void setIgnoreLibraryDeployConflict(boolean ignoreLibraryDeployConflict) {
         this.ignoreLibraryDeployConflict = ignoreLibraryDeployConflict;
+    }
+
+    public String getProcessName() {
+        return processName;
+    }
+
+    public void setProcessName(String processName) {
+        this.processName = processName;
+    }
+
+    public String getProcessNames() {
+        return processNames;
+    }
+
+    public void setProcessNames(String processNames) {
+        this.processNames = processNames;
     }
 }

--- a/src/main/resources/com/uipath/uipathpackage/UiPathDeploy/config.jelly
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathDeploy/config.jelly
@@ -57,6 +57,12 @@
     <f:entry title="${%EntryPoints}" field="entryPointPaths">
         <f:textbox default="Main.xaml"/>
     </f:entry>
+    <f:entry title="${%ProcessName}" field="processName">
+            <f:textbox/>
+    </f:entry>
+    <f:entry title="${%ProcessNames}" field="processNames">
+            <f:textbox/>
+    </f:entry>
     <f:entry title="${%ChooseAuthenticationMethod}" field="credentialsEntry">
         <f:hetero-radio field="credentials" descriptors="${descriptor.authenticationDescriptors}"/>
     </f:entry>

--- a/src/main/resources/com/uipath/uipathpackage/UiPathDeploy/config.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathDeploy/config.properties
@@ -9,4 +9,6 @@ CreateProcess=Automatically create/update process
 EntryPoints=Entry Point Path(s)
 ChooseAuthenticationMethod=Authentication
 IgnoreLibraryDeployConflict=Ignore library deploy conflict
+ProcessName=Process name
+ProcessNames=Process names
 TraceLevel=Trace logging level


### PR DESCRIPTION
## What changed?
Add new parameter to Deploy task.

## Why is this change necessary?
To enable multiple processes from a single nupkg to be created with custom names.

## How has this been tested?
Manual testing.

## Are there any breaking changes?
- [x] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version