### PR TITLE
fix: jenkins build deps for release 4.0 [AUOPS-4287]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,15 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <powershell.version>1.7</powershell.version>
         <envinject.version>2.4.0</envinject.version>
         <mockito-core.version>4.8.0</mockito-core.version>
         <plain-credentials.version>179.vc5cb_98f6db_38</plain-credentials.version>
         <json.version>20231013</json.version>
         <credentials.version>1319.v7eb_51b_3a_c97b_</credentials.version>
-        <org.jenkins-ci.plugins.junit.version>1265.v65b_14fa_f12f0</org.jenkins-ci.plugins.junit.version>
+        <org.jenkins-ci.plugins.junit.version>1304.vc85a_b_ca_96613</org.jenkins-ci.plugins.junit.version>
         <JUnitParams.version>1.1.1</JUnitParams.version>
-        <matrix-project.version>1.20</matrix-project.version>
         <native2ascii-maven-plugin.version>2.0.1</native2ascii-maven-plugin.version>
         <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
@@ -35,6 +34,15 @@
         <structs.version>325.vcb_307d2a_2782</structs.version>
         <caffeine-api.version>3.1.8-133.v17b_1ff2e0599</caffeine-api.version>
         <instance-identity.version>185.v303dc7c645f9</instance-identity.version>
+        <plugin-util-api.version>3.8.0</plugin-util-api.version>
+        <commons-text-api.version>1.10.0-78.v3e7b_ea_d5a_fe1</commons-text-api.version>
+        <workflow-support.version>865.v43e78cc44e0d</workflow-support.version>
+        <font-awesome-api.version>6.4.2-1</font-awesome-api.version>
+        <bootstrap5-api.version>5.3.2-3</bootstrap5-api.version>
+        <checks-api.version>2.0.2</checks-api.version>
+        <jquery3-api.version>3.7.1-1</jquery3-api.version>
+        <echarts-api.version>5.4.0-7</echarts-api.version>
+        <matrix-project.version>789.v57a_725b_63c79</matrix-project.version>
     </properties>
 
     <name>UiPath Plugin</name>
@@ -299,6 +307,51 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>caffeine-api</artifactId>
             <version>${caffeine-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>plugin-util-api</artifactId>
+            <version>${plugin-util-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-text-api</artifactId>
+            <version>${commons-text-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>${workflow-support.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>font-awesome-api</artifactId>
+            <version>${font-awesome-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>bootstrap5-api</artifactId>
+            <version>${bootstrap5-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>checks-api</artifactId>
+            <version>${checks-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jquery3-api</artifactId>
+            <version>${jquery3-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>echarts-api</artifactId>
+            <version>${echarts-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>${matrix-project.version}</version>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/main/java/com/uipath/uipathpackage/UiPathTest.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathTest.java
@@ -58,7 +58,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
     private final TraceLevel traceLevel;
     private boolean attachRobotLogs;
     private Boolean disableBuiltInNugetFeeds;
-    
+
     private static int TimeoutDefault = 7200;
 
     /**
@@ -91,7 +91,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
         this.credentials = credentials;
         this.timeout = timeout;
         this.testResultsOutputPath = testResultsOutputPath;
-		this.parametersFilePath = parametersFilePath;
+        this.parametersFilePath = parametersFilePath;
         this.disableBuiltInNugetFeeds = null;
         this.repositoryUrl = null;
         this.repositoryCommit = null;
@@ -181,7 +181,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
             testOptions.setTestReportType("junit");
 
             String resultsOutputPath = testResultsOutputPath != null && !testResultsOutputPath.trim().isEmpty()
-                                       ? testResultsOutputPath : "UiPathResults.xml";
+                    ? testResultsOutputPath : "UiPathResults.xml";
 
             FilePath expandedTestResultsOutputPath = resultsOutputPath.contains("${WORKSPACE}") ?
                     new FilePath(launcher.getChannel(), envVars.expand(resultsOutputPath)) :
@@ -208,7 +208,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
 
                 testOptions.setParametersFilePath(parametersPath.getRemote());
             }
-            
+
             testOptions.setAttachRobotLogs(attachRobotLogs);
 
             testOptions.setRepositoryUrl(repositoryUrl);
@@ -529,6 +529,11 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
     }
 
     @Override
+    public boolean isKeepTestNames() {
+        return false;
+    }
+
+    @Override
     public boolean isAllowEmptyResults() {
         return true;
     }
@@ -669,7 +674,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
 
             return FormValidation.ok();
         }
-        
+
         /**
          * Validates that the timeout is specified
          *


### PR DESCRIPTION
## What changed?
Update jenkins dependencies so that project can be built.

## Why is this change necessary?
So that release branch can build the project.

## How has this been tested?
E2E tests.

## Are there any breaking changes?
- [ ] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version
- [X] Dependency upgrades