### PR TITLE
fix: update CodeQL version [AUOPS-4405]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ resources:
       endpoint: "GitHub connection"
     - repository: codeql
       name: UiPath/AzurePipelinesTemplates
-      ref: refs/tags/uipath.security.codeql.1.8.13
+      ref: refs/tags/uipath.security.codeql.1.8.16
       type: github
       endpoint: "GitHub connection"
     - repository: fossa


### PR DESCRIPTION
## What changed?
Upgrade CodeQL pipeline template version to `1.8.16`.

## Why is this change necessary?
CLI was using an outdated version of the pipeline template.

## How has this been tested?
Describe testing done to verify the PR changes.
List any relevant details regarding steps to reproduce or test configuration.

## Are there any breaking changes?
- [x] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version